### PR TITLE
Modified setEventNames to return empty array instead of FALSE for PHP8

### DIFF
--- a/DictionarySearch.php
+++ b/DictionarySearch.php
@@ -174,20 +174,28 @@ class DictionarySearch extends AbstractExternalModule
 
     }
 
-    /**
-     * Set eventNames using REDCap method.
-     */
-    private function setEventNames(): void
-    {
-        $this->eventNames = REDCap::getEventNames(true, false);
-    }
+	/**
+	 * Set eventNames using REDCap method.
+	 */
+	private function setEventNames(): void
+	{
+		$eventNames = REDCap::getEventNames(true, false);
+		if ($eventNames === false) {
+			$eventNames = []; // Set to an empty array if false is returned
+		}
+		$this->eventNames = $eventNames;
+	}
 
     /**
      * Set eventLabels using REDCap method.
      */
     private function setEventNameLabels(): void
     {
-        $this->eventLabels = REDCap::getEventNames(false, false);
+        $eventLabels = REDCap::getEventNames(false, false);
+		if ($eventLabels === false) {
+			$eventLabels = []; // Set to an empty array if false is returned
+		}
+		$this->eventLabels = $eventLabels;
     }
 
     /**


### PR DESCRIPTION
As per [this](https://redcap.vanderbilt.edu/community/post.php?id=211768) report, throws an error under PHP8 since the REDCap::getEventNames returns bool FALSE if the project is not longitudinal. This PR ensures that setEventNames (and for completeness, setEventLabels, though it appears not to be used) returns an empty array in non-longitudinal projects.